### PR TITLE
Make CRDs installation and ServiceAccount name configurable

### DIFF
--- a/charts/kafka-operator/crds/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-crd.yaml
@@ -4,11 +4,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
   labels:
-    app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
-    helm.sh/chart: {{ include "kafka-operator.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/name: kafka-operator
+    helm.sh/chart: kafka-operator
+    app.kubernetes.io/instance: kafka-operator
+    app.kubernetes.io/managed-by: kafka-operator
     app.kubernetes.io/component: operator
   name: kafkaclusters.kafka.banzaicloud.io
 spec:

--- a/charts/kafka-operator/crds/operator-kafka-topic-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-topic-crd.yaml
@@ -4,26 +4,25 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
   labels:
-    app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
-    helm.sh/chart: {{ include "kafka-operator.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/name: kafka-operator
+    helm.sh/chart: kafka-operator
+    app.kubernetes.io/instance: kafka-operator
+    app.kubernetes.io/managed-by: kafka-operator
     app.kubernetes.io/component: operator
-  name: kafkausers.kafka.banzaicloud.io
+  name: kafkatopics.kafka.banzaicloud.io
 spec:
   group: kafka.banzaicloud.io
   names:
-    kind: KafkaUser
-    listKind: KafkaUserList
-    plural: kafkausers
-    singular: kafkauser
+    kind: KafkaTopic
+    listKind: KafkaTopicList
+    plural: kafkatopics
+    singular: kafkatopic
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      description: KafkaUser is the Schema for the kafka users API
+      description: KafkaTopic is the Schema for the kafkatopics API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -38,7 +37,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: KafkaUserSpec defines the desired state of KafkaUser
+          description: KafkaTopicSpec defines the desired state of KafkaTopic
           properties:
             clusterRef:
               description: ClusterReference states a reference to a cluster for topic/user
@@ -51,53 +50,29 @@ spec:
               required:
                 - name
               type: object
-            dnsNames:
-              items:
+            config:
+              additionalProperties:
                 type: string
-              type: array
-            includeJKS:
-              type: boolean
-            secretName:
+              type: object
+            name:
               type: string
-            topicGrants:
-              items:
-                description: UserTopicGrant is the desired permissions for the KafkaUser
-                properties:
-                  accessType:
-                    description: KafkaAccessType hold info about Kafka ACL
-                    enum:
-                      - read
-                      - write
-                    type: string
-                  patternType:
-                    description: KafkaPatternType hold the Resource Pattern Type of
-                      kafka ACL
-                    enum:
-                      - literal
-                      - match
-                      - prefixed
-                      - any
-                    type: string
-                  topicName:
-                    type: string
-                required:
-                  - accessType
-                  - topicName
-                type: object
-              type: array
+            partitions:
+              format: int32
+              type: integer
+            replicationFactor:
+              format: int32
+              type: integer
           required:
             - clusterRef
-            - secretName
+            - name
+            - partitions
+            - replicationFactor
           type: object
         status:
-          description: KafkaUserStatus defines the observed state of KafkaUser
+          description: KafkaTopicStatus defines the observed state of KafkaTopic
           properties:
-            acls:
-              items:
-                type: string
-              type: array
             state:
-              description: UserState defines the state of a KafkaUser
+              description: TopicState defines the state of a KafkaTopic
               type: string
           required:
             - state

--- a/charts/kafka-operator/crds/operator-kafka-user-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-user-crd.yaml
@@ -2,29 +2,27 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kafka-operator.fullname" . }}-server-cert
     controller-gen.kubebuilder.io/version: v0.2.5
   labels:
-    app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
-    helm.sh/chart: {{ include "kafka-operator.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/name: kafka-operator
+    helm.sh/chart: kafka-operator
+    app.kubernetes.io/instance: kafka-operator
+    app.kubernetes.io/managed-by: kafka-operator
     app.kubernetes.io/component: operator
-  name: kafkatopics.kafka.banzaicloud.io
+  name: kafkausers.kafka.banzaicloud.io
 spec:
   group: kafka.banzaicloud.io
   names:
-    kind: KafkaTopic
-    listKind: KafkaTopicList
-    plural: kafkatopics
-    singular: kafkatopic
+    kind: KafkaUser
+    listKind: KafkaUserList
+    plural: kafkausers
+    singular: kafkauser
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      description: KafkaTopic is the Schema for the kafkatopics API
+      description: KafkaUser is the Schema for the kafka users API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -39,7 +37,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: KafkaTopicSpec defines the desired state of KafkaTopic
+          description: KafkaUserSpec defines the desired state of KafkaUser
           properties:
             clusterRef:
               description: ClusterReference states a reference to a cluster for topic/user
@@ -52,29 +50,53 @@ spec:
               required:
                 - name
               type: object
-            config:
-              additionalProperties:
+            dnsNames:
+              items:
                 type: string
-              type: object
-            name:
+              type: array
+            includeJKS:
+              type: boolean
+            secretName:
               type: string
-            partitions:
-              format: int32
-              type: integer
-            replicationFactor:
-              format: int32
-              type: integer
+            topicGrants:
+              items:
+                description: UserTopicGrant is the desired permissions for the KafkaUser
+                properties:
+                  accessType:
+                    description: KafkaAccessType hold info about Kafka ACL
+                    enum:
+                      - read
+                      - write
+                    type: string
+                  patternType:
+                    description: KafkaPatternType hold the Resource Pattern Type of
+                      kafka ACL
+                    enum:
+                      - literal
+                      - match
+                      - prefixed
+                      - any
+                    type: string
+                  topicName:
+                    type: string
+                required:
+                  - accessType
+                  - topicName
+                type: object
+              type: array
           required:
             - clusterRef
-            - name
-            - partitions
-            - replicationFactor
+            - secretName
           type: object
         status:
-          description: KafkaTopicStatus defines the observed state of KafkaTopic
+          description: KafkaUserStatus defines the observed state of KafkaUser
           properties:
+            acls:
+              items:
+                type: string
+              type: array
             state:
-              description: TopicState defines the state of a KafkaTopic
+              description: UserState defines the state of a KafkaUser
               type: string
           required:
             - state

--- a/charts/kafka-operator/templates/_helpers.tpl
+++ b/charts/kafka-operator/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "kafka-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Compute operator deployment serviceAccountName key
+*/}}
+{{- define "operator.serviceAccountName" -}}
+{{- if .Values.operator.serviceAccount.create -}}
+{{ default "default" .Values.operator.serviceAccount.name }}
+{{- else -}}
+{{- printf "%s" "default" }}
+{{- end -}}
+{{- end -}}

--- a/charts/kafka-operator/templates/authproxy-rbac.yaml
+++ b/charts/kafka-operator/templates/authproxy-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.enabled .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
+{{- if and .Values.prometheusMetrics.authProxy.serviceAccount.create .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.imagePullSecrets }}
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: {{ include "kafka-operator.fullname" . }}-authproxy
+  name: {{ .Values.prometheusMetrics.authProxy.serviceAccount.name }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
@@ -17,6 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: authproxy
+{{- end }}
+{{- if and .Values.rbac.enabled .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -56,6 +58,6 @@ roleRef:
   name: "{{ include "kafka-operator.fullname" . }}-authproxy"
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kafka-operator.fullname" . }}-authproxy
+  name: {{ .Values.prometheusMetrics.authProxy.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.crd.enabled }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -34,9 +34,7 @@ spec:
         app: prometheus
         component: alertmanager
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "kafka-operator.fullname" . }}-operator
-      {{- end }}
+      serviceAccountName: {{ include "operator.serviceAccountName" .}}
       volumes:
       {{- if .Values.webhook.enabled }}
         - name: serving-cert

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.operator.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.imagePullSecrets }}
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: {{ include "kafka-operator.fullname" . }}-operator
+  name: {{ include "operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
@@ -17,6 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: operator
+{{- end }}
+{{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -237,6 +239,6 @@ roleRef:
   name: {{ include "kafka-operator.fullname" . }}-operator
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kafka-operator.fullname" . }}-operator
+  name: {{ include "operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -54,6 +54,8 @@ fullnameOverride: ""
 rbac:
   enabled: true
 
+crd:
+  enabled: false
 nodeSelector: {}
 
 tolerations: []

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -26,6 +26,9 @@ operator:
     requests:
       cpu: 100m
       memory: 128Mi
+  serviceAccount:
+    create: true
+    name: kafka-operator
 
 webhook:
   enabled: true
@@ -47,6 +50,10 @@ prometheusMetrics:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.4.0
       pullPolicy: IfNotPresent
+    serviceAccount:
+      create: true
+      name: kafka-operator-authproxy
+
 
 nameOverride: ""
 fullnameOverride: ""
@@ -56,6 +63,7 @@ rbac:
 
 crd:
   enabled: false
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
We needed more control on what resources are being created by the helm chart in restricted k8s environments.

### Additional context
We needed the following functionality:
- enable/disable rbac
- enable/disable crd's
- enable/disable service account creation
- customize service account name


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

