### PR TITLE
Remove Prometheus scraping hardcoded annotations

### DIFF
--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -185,7 +185,6 @@ func GeneratePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger,
 			"cruiseControlConfig.json":        hex.EncodeToString(hashedCruiseControlConfigJson[:]),
 			"cruiseControlClusterConfig.json": hex.EncodeToString(hashedCruiseControlClusterConfigJson[:]),
 		},
-		util.MonitoringAnnotations(metricsPort),
 	}
 
 	return util.MergeAnnotations(annotations...)

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -102,16 +102,13 @@ fi
 	}
 
 	pod := &corev1.Pod{
-		ObjectMeta: templates.ObjectMetaWithGeneratedNameAndAnnotations(
+		ObjectMeta: templates.ObjectMetaWithGeneratedName(
 			fmt.Sprintf("%s-%d-", r.KafkaCluster.Name, id),
 			util.MergeLabels(
 				LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
 			),
-			util.MergeAnnotations(
-				brokerConfig.GetBrokerAnnotations(),
-				util.MonitoringAnnotations(metricsPort),
-			), r.KafkaCluster,
+			r.KafkaCluster,
 		),
 		Spec: corev1.PodSpec{
 			InitContainers: append(initContainers, []corev1.Container{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -91,14 +91,6 @@ func MergeLabels(l ...map[string]string) map[string]string {
 	return res
 }
 
-// MonitoringAnnotations returns specific prometheus annotations
-func MonitoringAnnotations(port int) map[string]string {
-	return map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   strconv.Itoa(port),
-	}
-}
-
 func MergeAnnotations(annotations ...map[string]string) map[string]string {
 	rtn := make(map[string]string)
 	for _, a := range annotations {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -183,17 +183,6 @@ func TestMergeLabels(t *testing.T) {
 	}
 }
 
-func TestMonitoringAnnotations(t *testing.T) {
-	expected := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "9001",
-	}
-	anntns := MonitoringAnnotations(int(9001))
-	if !reflect.DeepEqual(expected, anntns) {
-		t.Error("Expected:", expected, "Got:", anntns)
-	}
-}
-
 func TestConvertStringToInt32(t *testing.T) {
 	i := ConvertStringToInt32("10")
 	if i != 10 {
@@ -244,7 +233,7 @@ func TestStringSliceRemove(t *testing.T) {
 }
 
 func TestMergeAnnotations(t *testing.T) {
-	annotations := MonitoringAnnotations(8888)
+	annotations := map[string]string{"foo": "bar", "bar": "foo"}
 	annotations2 := map[string]string{"thing": "1", "other_thing": "2"}
 
 	combined := MergeAnnotations(annotations, annotations2)


### PR DESCRIPTION
Using Service Monitors would result in metrics duplication (since CC and Kafka pods are always scraped due to some hard coded annotations).

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
