### PR TITLE
Remove Prometheus scraping hardcoded annotations

### DIFF
--- a/charts/kafka-operator/crds/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-crd.yaml
@@ -64,6 +64,11 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                    description: 'Custom annotations for the broker pods:
+                      e.g.: Prometheus scraping annotations:
+                        prometheus.io/scrape: "true"
+                        prometheus.io/port: "9020"
+                      '
                   config:
                     type: string
                   image:
@@ -514,6 +519,11 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                        description: 'Custom annotations for the broker pods:
+                          e.g.: Prometheus scraping annotations:
+                            prometheus.io/scrape: "true"
+                            prometheus.io/port: "9020"
+                          '
                       config:
                         type: string
                       image:

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -44,7 +44,7 @@ kind: ServiceMonitor
 metadata:
   name: cruisecontrol-servicemonitor
   labels:
-    app: kafka
+    app: cruisecontrol
     kafka_cr: kafka
     release: prometheus-operator
 spec:

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -23,6 +23,9 @@ spec:
             resources:
               requests:
                 storage: 10Gi
+      brokerAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9020"
   brokers:
     - id: 0
       brokerConfigGroup: "default"

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -185,7 +185,6 @@ func GeneratePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger,
 			"cruiseControlConfig.json":        hex.EncodeToString(hashedCruiseControlConfigJson[:]),
 			"cruiseControlClusterConfig.json": hex.EncodeToString(hashedCruiseControlClusterConfigJson[:]),
 		},
-		util.MonitoringAnnotations(metricsPort),
 	}
 
 	return util.MergeAnnotations(annotations...)

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -108,10 +108,8 @@ fi
 				LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
 			),
-			util.MergeAnnotations(
-				brokerConfig.GetBrokerAnnotations(),
-				util.MonitoringAnnotations(metricsPort),
-			), r.KafkaCluster,
+			brokerConfig.GetBrokerAnnotations(),
+			r.KafkaCluster,
 		),
 		Spec: corev1.PodSpec{
 			InitContainers: append(initContainers, []corev1.Container{

--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -72,7 +72,7 @@ func ObjectMetaWithAnnotations(name string, labels map[string]string, annotation
 	return o
 }
 
-// ObjectMetaWithGeneratedNameAndAnnotations returns a metav1.ObjectMeta object with labels, ownerReference, generatedname and annotations
+// ObjectMetaWithGeneratedNameAndAnnotations returns a metav1.ObjectMeta object with labels, ownerReference, generatedName and annotations
 func ObjectMetaWithGeneratedNameAndAnnotations(namePrefix string, labels map[string]string, annotations map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
 	o := ObjectMetaWithGeneratedName(namePrefix, labels, cluster)
 	o.Annotations = annotations

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -91,14 +91,6 @@ func MergeLabels(l ...map[string]string) map[string]string {
 	return res
 }
 
-// MonitoringAnnotations returns specific prometheus annotations
-func MonitoringAnnotations(port int) map[string]string {
-	return map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   strconv.Itoa(port),
-	}
-}
-
 func MergeAnnotations(annotations ...map[string]string) map[string]string {
 	rtn := make(map[string]string)
 	for _, a := range annotations {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -183,17 +183,6 @@ func TestMergeLabels(t *testing.T) {
 	}
 }
 
-func TestMonitoringAnnotations(t *testing.T) {
-	expected := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "9001",
-	}
-	anntns := MonitoringAnnotations(int(9001))
-	if !reflect.DeepEqual(expected, anntns) {
-		t.Error("Expected:", expected, "Got:", anntns)
-	}
-}
-
 func TestConvertStringToInt32(t *testing.T) {
 	i := ConvertStringToInt32("10")
 	if i != 10 {
@@ -244,7 +233,7 @@ func TestStringSliceRemove(t *testing.T) {
 }
 
 func TestMergeAnnotations(t *testing.T) {
-	annotations := MonitoringAnnotations(8888)
+	annotations := map[string]string{"foo": "bar", "bar": "foo"}
 	annotations2 := map[string]string{"thing": "1", "other_thing": "2"}
 
 	combined := MergeAnnotations(annotations, annotations2)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/kafka-operator/issues/398
| License         | Apache 2.0


### What's in this PR?
In https://github.com/banzaicloud/kafka-operator/issues/398 it was reported that adding a Service Monitor for metric scraping would generate metric duplicates since Kafka brokers are already scraped using (hard coded) Prometheus annotations. These Prometheus annotations were removed to allow users to use Service Monitors instead


### Additional context
Prometheus annotations were used to scrape both Broker metrics and Cruise Control metrics.
Prometheus recommends the use of Service Monitors for metrics scraping (this would increase scraping flexibility as well): https://github.com/banzaicloud/kafka-operator/blob/master/config/samples/kafkacluster-prometheus.yaml

For broker metrics, there is still a workaround to use Prometheus annotations: `brokerAnnotations` property.
For Cruise Control, at this point, the only option is to create a service monitor.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
- [ ] Should we also add a property for Cruise Control, similar to `brokerAnnotations`, to offer an alternative for the Service Monitor?
- [ ] Should we update the documentation with more information about the metrics scraping using a Service Monitor?
