### PR TITLE
Reload Envoy ingress controller configuration on KafkaCluster scale up

### DIFF
--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -39,12 +39,12 @@ import (
 func (r *Reconciler) configMap(log logr.Logger, envoyConfig *v1beta1.EnvoyConfig) runtime.Object {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: templates.ObjectMeta(configName(envoyConfig), labelSelector(envoyConfig), r.KafkaCluster),
-		Data:       map[string]string{"envoy.yaml": generateEnvoyConfig(r.KafkaCluster, envoyConfig, log)},
+		Data:       map[string]string{"envoy.yaml": GenerateEnvoyConfig(r.KafkaCluster, envoyConfig, log)},
 	}
 	return configMap
 }
 
-func generateEnvoyConfig(kc *v1beta1.KafkaCluster, envoyConfig *v1beta1.EnvoyConfig, log logr.Logger) string {
+func GenerateEnvoyConfig(kc *v1beta1.KafkaCluster, envoyConfig *v1beta1.EnvoyConfig, log logr.Logger) string {
 	//TODO support multiple external listener by removing [0] (baluchicken)
 	adminConfig := envoybootstrap.Admin{
 		AccessLogPath: "/tmp/admin_access.log",


### PR DESCRIPTION
See https://github.com/banzaicloud/kafka-operator/issues/438
This is an internal patch on top of multi-az envoy patch.

While writing this patch I realised that this works fine for cluster "scale-up" when new brokers are added as they are automatically added in ingress as well. 

But not behaving that good for `scale-down` events when brokers are removed:
- one a broker is removed from KafkaCluster `spec` the operator does two things:
 (1) triggers the broker clean decomissioning in CC (i.e. waiting for partitions to move off that broker)
 (2) updates envoy config
As (1) is slower and (2) is faster there is a window of time during which the broker still has partitions but it's not reachable via ingress 
I suggest we solve the "scale-down" behaviour in a separate patch though as it's a rarer event.
Also - to implement it - the change is not that trivial as we need to check also KafkaCluster.Status.BrokerState field not only the Spec. 
