### PR TITLE
Added KafkaCluster CR labels to the deployment template spec

### DIFF
--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -40,7 +40,7 @@ func (r *Reconciler) deployment(log logr.Logger, envoyConfig *v1beta1.EnvoyConfi
 			Replicas: util.Int32Pointer(envoyConfig.GetReplicas()),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labelSelector(envoyConfig),
+					Labels:      util.MergeLabels(labelSelector(envoyConfig), r.KafkaCluster.Labels),
 					Annotations: generatePodAnnotations(r.KafkaCluster, envoyConfig, log),
 				},
 				Spec: getPodSpec(log, envoyConfig, r.KafkaCluster),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Small changes to the envoy deployment created by the operator to add the KafkaCR labels in the template spec.

### Why?
Setting labels in the KafkaCR does not transfer down to the envoy resources. As such when trying to deploy to a specific worker group bound with a label, it's not possible to pin the envoy resources at the current version.


### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
