### PR TITLE
feat: Add HostnamePrefix in broker configuration

### DIFF
--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -705,6 +705,11 @@ spec:
                     type: object
                   config:
                     type: string
+                  hostnamePrefix:
+                    description: Hostname prefix it is used together with HostnameOverride
+                      to advertise a specific format for the broker address. The default
+                      hostname prefix format is <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace>
+                    type: string
                   image:
                     type: string
                   imagePullSecrets:
@@ -1884,6 +1889,11 @@ spec:
                           prometheus.io/port: "9020"'
                         type: object
                       config:
+                        type: string
+                      hostnamePrefix:
+                        description: Hostname prefix it is used together with HostnameOverride
+                          to advertise a specific format for the broker address. The
+                          default hostname prefix format is <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace>
                         type: string
                       image:
                         type: string
@@ -5590,7 +5600,9 @@ spec:
                           instead of public IP). In case of external listeners using
                           NodePort access method the broker instead of node public
                           IP (see "brokerConfig.nodePortExternalIP") is advertised
-                          on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>'
+                          on the address having the following format: <value-specified-in-hostnamePrefix-field><value-specified-in-hostnameOverride-field>
+                          If hostnamePrefix is missing (or empty) the advertised address
+                          will have the following format: <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace><value-specified-in-hostnameOverride-field>'
                         type: string
                       name:
                         type: string

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -706,6 +706,11 @@ spec:
                     type: object
                   config:
                     type: string
+                  hostnamePrefix:
+                    description: Hostname prefix it is used together with HostnameOverride
+                      to advertise a specific format for the broker address. The default
+                      hostname prefix format is <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace>
+                    type: string
                   image:
                     type: string
                   imagePullSecrets:
@@ -1885,6 +1890,11 @@ spec:
                           prometheus.io/port: "9020"'
                         type: object
                       config:
+                        type: string
+                      hostnamePrefix:
+                        description: Hostname prefix it is used together with HostnameOverride
+                          to advertise a specific format for the broker address. The
+                          default hostname prefix format is <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace>
                         type: string
                       image:
                         type: string
@@ -5591,7 +5601,9 @@ spec:
                           instead of public IP). In case of external listeners using
                           NodePort access method the broker instead of node public
                           IP (see "brokerConfig.nodePortExternalIP") is advertised
-                          on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>'
+                          on the address having the following format: <value-specified-in-hostnamePrefix-field><value-specified-in-hostnameOverride-field>
+                          If hostnamePrefix is missing (or empty) the advertised address
+                          will have the following format: <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace><value-specified-in-hostnameOverride-field>'
                         type: string
                       name:
                         type: string

--- a/config/samples/simplekafkacluster-with-nodeport-external.yaml
+++ b/config/samples/simplekafkacluster-with-nodeport-external.yaml
@@ -64,7 +64,7 @@ spec:
 
         # if specified that the broker instead of node public IP (see "brokerConfig.nodePortExternalIP")
         #	is advertised on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>
-        hostnameOverride: ".my.internal.domain" # brokers will be advertised as kafka-<broker-id>.<namespace>.my.internal.domain (e.g. kafka-0.kafka.my.internal.domain)
+        hostnameOverride: ".my.internal.domain" # brokers will be advertised as kafka-<broker-id>.<namespace>.my.internal.domain (e.g. kafka-0.kafka.my.internal.domain). Check "hostnamePrefix" parameter to use a different format for the brokers.
 
         externalTrafficPolicy: "Local" # either Local or Cluster. If omitted defaults to Cluster.
 

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -851,7 +851,11 @@ func (r *Reconciler) createExternalListenerStatuses() (map[string]v1beta1.Listen
 				if brokerHost == "" {
 					brokerHost = bConfig.NodePortExternalIP[eListener.Name]
 				} else {
-					brokerHost = fmt.Sprintf("%s-%d-%s.%s%s", r.KafkaCluster.Name, broker.Id, eListener.Name, r.KafkaCluster.Namespace, brokerHost)
+					hostnamePrefix := bConfig.HostnamePrefix
+					if hostnamePrefix == "" {
+						hostnamePrefix = fmt.Sprintf("%s-%d-%s.%s", r.KafkaCluster.Name, broker.Id, eListener.Name, r.KafkaCluster.Namespace)
+					}
+					brokerHost = fmt.Sprintf("%s%s", hostnamePrefix, brokerHost)
 				}
 			}
 

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -140,6 +140,9 @@ type BrokerConfig struct {
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// SecurityContext allows to set security context for the kafka container
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+	// Hostname prefix it is used together with HostnameOverride to advertise a specific format for the broker address.
+	// The default hostname prefix format is <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace>
+	HostnamePrefix string `json:"hostnamePrefix,omitempty"`
 }
 
 type NetworkConfig struct {
@@ -335,7 +338,8 @@ type ExternalListenerConfig struct {
 	// Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to
 	// advertise the listener using a URL recorded in DNS instead of public IP).
 	// In case of external listeners using NodePort access method the broker instead of node public IP (see "brokerConfig.nodePortExternalIP")
-	// is advertised on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>
+	// is advertised on the address having the following format: <value-specified-in-hostnamePrefix-field><value-specified-in-hostnameOverride-field>
+	// If hostnamePrefix is missing (or empty) the advertised address will have the following format: <kafka-cluster-name>-<broker-id>-<listener-name>.<namespace><value-specified-in-hostnameOverride-field>
 	HostnameOverride   string            `json:"hostnameOverride,omitempty"`
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 	// +kubebuilder:validation:Enum=LoadBalancer;NodePort


### PR DESCRIPTION
This would allow to customize the format of the HostnameOverride

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Related to https://github.com/banzaicloud/kafka-operator/pull/519
| License         | Apache 2.0


### What's in this PR?
In https://github.com/banzaicloud/kafka-operator/pull/519 , the `hostnameOverride` parameter behavior was changed. Now, `hostnameOverride` is just a suffix (and no longer the full fqdn).
This PR adds more flexibility to the `hostnameOverride`, adding the option to set a custom prefix in the broker config.


### Why?
Add custom prefix for broker external name, configurable at broker (or group) level.

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
